### PR TITLE
0.7.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,6 @@ jobs:
 
       - run: just setup
       - run: just build
-      - run: DEBUG=true just test
+      - run: DEBUG=1 just test
 
   # TODO: build and upload to release tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Tips
+
+## Nerd Fonts
+
+Nerd Font icons come in two variants. If the font was called "A", the the variants are:
+
+* "A Nerd Font"
+* "A Nerd Font Mono"
+
+The one with the "Mono" suffix has all the icons 'squashed' into a single monospace character's width.
+This is a compatibility for programs that don't support double-width characters, but does make some of the icons appear too small.
+
+Unfortunately, as far as I can tell, i3's statusbar doesn't properly support the double-width character icons.
+So, if the normal font is used, sometimes the icons appear to overlap neighbouring characters.
+
+## Debugging integration tests
+
+The following environment variables are available:
+
+* `DEBUG=1`: increases logs when spawning processes (e.g., `DEBUG=1 cargo test -- --ncapture <test>`)
+* `XEPHYR=1`: run X tests with `Xephyr` rather than `Xvfb`
+
+## Why `Rc<str>` over `String`, or `Rc<[T]>` over `Vec<T>` in struct fields?
+
+It's a cheaper method of keeping immutable data around without having to reallocate the inner data every time.
+Since mutating the data isn't necessary, this can just point the the exiting data and we get cheap clones.
+See https://www.youtube.com/watch?v=A4cKi7PTJSs for a good explanation.
+
+# Creating the next release
+
+All new development is done on the `next` branch. When it's time to make a release, a PR is created to `master`.
+This is mainly here so I remember how to do a release when I haven't done one in a while.
+
+Steps:
+
+1. Create GH PR from `next` to `master`
+2. Test publish locally with `just test-publish`
+3. Push commit with version bump
+4. Run `just publish` and make sure the AUR is also updated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "istat"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "istat"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A lightweight and batteries-included status_command for i3 and sway"
 license = "GPL-3.0-only"

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -15,31 +15,3 @@ There's no guarantee they'll ever be added or implemented, and they'll likely be
 
 * CI builds and automatic release publishing
 * a bin PKGBUILD for the AUR
-
-## Tips
-
-### Nerd Fonts
-
-Nerd Font icons come in two variants. If the font was called "A", the the variants are:
-
-* "A Nerd Font"
-* "A Nerd Font Mono"
-
-The one with the "Mono" suffix has all the icons 'squashed' into a single monospace character's width.
-This is a compatibility for programs that don't support double-width characters, but does make some of the icons appear too small.
-
-Unfortunately, as far as I can tell, i3's statusbar doesn't properly support the double-width character icons.
-So, if the normal font is used, sometimes the icons appear to overlap neighbouring characters.
-
-### Debugging integration tests
-
-The following environment variables are available:
-
-* `DEBUG=1`: increases logs when spawning processes (e.g., `DEBUG=1 cargo test -- --ncapture <test>`)
-* `XEPHYR=1`: run X tests with `Xephyr` rather than `Xvfb`
-
-### Why `Rc<str>` over `String`, or `Rc<[T]>` over `Vec<T>` in struct fields?
-
-It's a cheaper method of keeping immutable data around without having to reallocate the inner data every time.
-Since mutating the data isn't necessary, this can just point the the exiting data and we get cheap clones.
-See https://www.youtube.com/watch?v=A4cKi7PTJSs for a good explanation.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -5,7 +5,6 @@ There's no guarantee they'll ever be added or implemented, and they'll likely be
 
 ## Features
 
-* a bin PKGBUILD for the AUR (would need to setup CI first)
 * man pages for all binaries
 
 ## Bugs
@@ -14,7 +13,8 @@ There's no guarantee they'll ever be added or implemented, and they'll likely be
 
 ## Improvements
 
-* ...
+* CI builds and automatic release publishing
+* a bin PKGBUILD for the AUR
 
 ## Tips
 

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ run bin *args:
 
 # install locally, copy sample configuration and restart i3
 install *args:
-  cargo install --offline --path . "$@"
+  RUSTFLAGS="--emit=asm" cargo install --offline --path . "$@"
   mkdir -p ~/.config/istat/
   -cp --no-clobber ./sample_config.toml ~/.config/istat/config.toml
   i3-msg restart

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -50,14 +50,18 @@ powerline = [
 #
 ## COMMON OPTIONS
 ## All items share the the following config options:
-# type:   required; the type of the item
-# name:   optional; a name for the item - makes some ipc operations easier
-# index:  optional; where to position this item in the bar - defaults to the current index in `items`
-# signal: optional; a real-time signal can be mapped to an item, and when istat receives this signal
-#                   the item will be refreshed - useful for manually triggering item updates.
-#                   The same signal can be used for multiple items.
-#                   The `istat-signals` command can be used to query limits for signals on the
-#                   current system.
+# type:   required;    the type of the item
+# name:   optional;    a name for the item - makes some ipc operations easier
+# index:  optional;    where to position this item in the bar - defaults to the current index in `items`
+# signal: optional;    a real-time signal can be mapped to an item, and when istat receives this signal
+#                      the item will be refreshed - useful for manually triggering item updates.
+#                      The same signal can be used for multiple items.
+#                      The `istat-signals` command can be used to query limits for signals on the
+#                      current system.
+# actions: optional;   custom commands to run when the item is clicked.
+#                      These actions take precedence over any item's default behaviour (e.g., the pulse
+#                      item already does things on click, but these actions would prevent that behaviour).
+#                      See the examples in these config files (search for `[items.actions]`).
 #
 ## FLOAT FORMAT OPTIONS
 ## Some items which display a floating point integer allow customising its format with these options:
@@ -89,11 +93,24 @@ thresholds = ["1kiB", "1MiB", "10MiB", "25MiB", "100MiB"]
 # ignored_interfaces = ["vpn0"]
 
 [[items]]
-# a raw item - these are static items that don't change, and display the values here
+# A raw item - these are static items that don't change, and display the values here
 type = "raw"
-# see i3's bar documentation for what fields are available: https://i3wm.org/docs/i3bar-protocol.html
+# See i3's bar documentation for what fields are available: https://i3wm.org/docs/i3bar-protocol.html
 full_text = "raw"
 short_text = "!"
+# This is an example of configuring custom actions for an item.
+# [items.actions] is available for every item type! (See the COMMON OPTIONS section above.)
+[items.actions]
+# Run a command
+left_click = "paplay /usr/share/sounds/freedesktop/stereo/bell.oga"
+# Run a command with specific modifiers
+middle_click = { modifiers = ["Shift"], command = "i3-msg exec nemo" }
+# Define different commands for different modifier combinations
+right_click = [
+  # Hint: triple quotes are an easy way to escape inner quotes in TOML.
+  { modifiers = ['Shift'], command = """ i3-msg exec "zenity --info --text 'HELLO FROM ISTAT!'" """ },
+  { modifiers = ['Control'], command = """ i3-msg exec "zenity --info --text 'hello from istat!'" """ },
+]
 
 [[items]]
 # Kerberos item - simply calls `klist` and displays the result
@@ -141,10 +158,13 @@ interval = "60s"
 
 [[items]]
 # CPU usage item - provides updates of CPU usage expressed as a percentage
+# Also includes FLOAT FORMAT OPTIONS
 type = "cpu"
 # How often this item should refresh
 interval = "2s"
-# Also includes FLOAT FORMAT OPTIONS
+# Open an application on click
+[items.actions]
+left_click = "i3-msg exec systemmonitor"
 
 [[items]]
 # Display the temperature of a given component.
@@ -174,10 +194,10 @@ display = "bytes"
 [[items]]
 # Display infomation about the current sink (sound output) and source (sound input). This is a very
 # versatile item and has a tight integration to pulseaudio/pipewire.
-# Scrolling up/down will change the volume of the current sink. The same while holding `Shift` will
-# change the volume of the current source.
-# Middle clicking will mute the current sink. The same with `Shift` will mute the current source.
-# Left clicking will execute `pavucontrol`.
+# Scrolling up/down will change the volume of the current sink.
+# Middle clicking will mute the current sink.
+# Left clicking will cycle between ports for the current sink (i.e., speakers, headphones, etc).
+# All of the above actions will affect the source rather than the sink while `shift` is held.
 #
 # This item also has a highly featured ipc interface, see `istat-ipc custom pulse` for more info.
 type = "pulse"
@@ -200,6 +220,9 @@ max_volume = 120
 notify = "none"
 
 # server_name = "pipewire-0"
+
+[items.actions]
+left_click = { modifiers = ["Control"], command = "i3-msg exec pavucontrol" }
 
 [[items]]
 # Show current light brightness (and also adjust it).
@@ -246,6 +269,9 @@ format_long = "%Y-%m-%d %H:%M:%S"
 format_short = "%H:%M"
 # How often this item should refresh
 interval = "1s"
+# Open a calendar when clicking on the time item
+[items.actions]
+left_click = "i3-msg exec gsimplecal"
 
 [[items]]
 # Run a script and display its output as an item. By default the command's STDOUT is displayed.

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -61,6 +61,7 @@ powerline = [
 # actions: optional;   custom commands to run when the item is clicked.
 #                      These actions take precedence over any item's default behaviour (e.g., the pulse
 #                      item already does things on click, but these actions would prevent that behaviour).
+#                      The item's fields are added to the command's environment (use `istat-ipc get-bar` to see fields).
 #                      See the examples in these config files (search for `[items.actions]`).
 #
 ## FLOAT FORMAT OPTIONS
@@ -155,6 +156,9 @@ type = "disk"
 interval = "60s"
 # Optionally only include these specific mount points
 # mounts = ["/"]
+[items.actions]
+# Open the currently displayed mount point:
+left_click = """ i3-msg exec "nemo $_mount_point" """
 
 [[items]]
 # CPU usage item - provides updates of CPU usage expressed as a percentage

--- a/sample_included_config.toml
+++ b/sample_included_config.toml
@@ -1,6 +1,6 @@
 # This file was included from main configuration file.
 
-# Example of adding an additional item.
+# Example of adding an additional item in the middle of an existing bar configuration.
 [[items]]
 type = "raw"
 # Specifying the index so we can insert this item in the already defined list of

--- a/src/bar_items/cpu.rs
+++ b/src/bar_items/cpu.rs
@@ -1,4 +1,3 @@
-use crate::error::Result;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -6,10 +5,10 @@ use hex_color::HexColor;
 use serde_derive::{Deserialize, Serialize};
 use sysinfo::{CpuExt, CpuRefreshKind, SystemExt};
 
-use crate::context::{BarEvent, BarItem, Context, StopAction};
+use crate::context::{BarItem, Context, StopAction};
+use crate::error::Result;
 use crate::i3::{I3Item, I3Markup};
 use crate::theme::Theme;
-use crate::util::exec;
 use crate::util::format::{float, FloatFormat};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -55,12 +54,7 @@ impl BarItem for Cpu {
             }
 
             ctx.update_item(item).await?;
-            ctx.delay_with_event_handler(self.interval, |event| async move {
-                if let BarEvent::Click(_) = event {
-                    exec("systemmonitor").await;
-                }
-            })
-            .await;
+            ctx.wait_for_event(Some(self.interval)).await;
         }
     }
 }

--- a/src/bar_items/disk.rs
+++ b/src/bar_items/disk.rs
@@ -90,7 +90,10 @@ impl BarItem for Disk {
                 let (full, short) = disk.format(theme);
                 let full = format!("{}{}", full, p.format(theme));
 
-                let mut item = I3Item::new(full).short_text(short).markup(I3Markup::Pango);
+                let mut item = I3Item::new(full)
+                    .short_text(short)
+                    .markup(I3Markup::Pango)
+                    .with_data("mount_point", disk.mount_point.clone().into());
 
                 if let Some(fg) = disk.get_color(theme) {
                     item = item.color(fg);

--- a/src/bar_items/krb.rs
+++ b/src/bar_items/krb.rs
@@ -59,7 +59,7 @@ impl BarItem for Krb {
                 Ok(interfaces) = net.wait_for_change() => {
                     // if none of the filters matched
                     if interfaces.filtered(&self.only_on).is_empty() {
-                        // if the item wasn't disabled, then empty it out
+                        // if the item was enabled, then empty it out
                         if enabled {
                             ctx.update_item(I3Item::empty()).await?;
                         }
@@ -69,6 +69,8 @@ impl BarItem for Krb {
 
                         // reset loop and wait to be enabled
                         continue;
+                    } else {
+                        enabled = true;
                     }
                 }
             }

--- a/src/bar_items/pulse/mod.rs
+++ b/src/bar_items/pulse/mod.rs
@@ -752,9 +752,6 @@ impl BarItem for Pulse {
                 Some(event) = ctx.raw_event_rx().recv() => match event {
                     BarEvent::Custom { payload, responder } => inner.handle_custom_message(payload, responder),
                     BarEvent::Click(click) => match click.button {
-                        // open control panel
-                        I3Button::Left if click.modifiers.contains(&I3Modifier::Control) => exec("i3-msg exec pavucontrol").await,
-
                         // cycle source ports
                         I3Button::Left if click.modifiers.contains(&I3Modifier::Shift) => {
                             inner.default_source().map(|io| inner.cycle_port(io, Object::Source));

--- a/src/bar_items/pulse/mod.rs
+++ b/src/bar_items/pulse/mod.rs
@@ -35,7 +35,7 @@ use crate::dbus::{dbus_connection, BusType};
 use crate::error::Result;
 use crate::i3::{I3Button, I3Item, I3Markup, I3Modifier};
 use crate::theme::Theme;
-use crate::util::{exec, expand_path, RcCell};
+use crate::util::{expand_path, RcCell};
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
 pub enum Object {
@@ -761,21 +761,6 @@ impl BarItem for Pulse {
                         I3Button::Left => {
                             inner.default_sink().map(|io| inner.cycle_port(io, Object::Sink));
                         }
-
-                        // show a popup with information about the current state
-                        I3Button::Right => {
-                            let s = |s: &str| s.chars().filter(char::is_ascii).collect::<String>();
-                            let m = |p: InOut| format!("name: {}\nvolume: {}\n", s(&p.name), p.volume_pct());
-                            let sink = inner.default_sink().map(m).unwrap_or("???".into());
-                            let source = inner.default_source().map(m).unwrap_or("???".into());
-                            exec(
-                                format!(
-                                    r#"zenity --info --text='[sink]\n{}\n\n[source]\n{}'"#,
-                                    sink,
-                                    source
-                                )
-                            ).await
-                        },
 
                         // source
                         I3Button::Middle if click.modifiers.contains(&I3Modifier::Shift) => {

--- a/src/bar_items/script.rs
+++ b/src/bar_items/script.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use crate::error::Result;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -7,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 use tokio::process::Command;
 
 use crate::context::{BarEvent, BarItem, Context, StopAction};
+use crate::error::Result;
 use crate::i3::{I3Item, I3Markup};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/src/bar_items/time.rs
+++ b/src/bar_items/time.rs
@@ -1,13 +1,12 @@
-use crate::error::Result;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::context::{BarEvent, BarItem, Context, StopAction};
-use crate::i3::{I3Button, I3Item, I3Markup};
-use crate::util::exec;
+use crate::context::{BarItem, Context, StopAction};
+use crate::error::Result;
+use crate::i3::{I3Item, I3Markup};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Time {
@@ -27,17 +26,7 @@ impl BarItem for Time {
                 .markup(I3Markup::Pango);
 
             ctx.update_item(item).await?;
-
-            ctx.delay_with_event_handler(self.interval, |event| async move {
-                match event {
-                    BarEvent::Click(click) => match click.button {
-                        I3Button::Left => exec("gsimplecal").await,
-                        _ => {}
-                    },
-                    _ => {}
-                }
-            })
-            .await;
+            ctx.wait_for_event(Some(self.interval)).await;
         }
     }
 }

--- a/src/config/item.rs
+++ b/src/config/item.rs
@@ -1,12 +1,46 @@
 use std::cell::OnceCell;
+use std::collections::HashSet;
 
 use serde_derive::{Deserialize, Serialize};
 use strum::EnumIter;
 
 use crate::bar_items::*;
 use crate::context::BarItem;
-use crate::i3::I3Item;
+use crate::i3::{I3Item, I3Modifier};
 
+/// Custom item action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Action {
+    /// Run the given command
+    Simple(String),
+    /// Run the given command, if the modifiers are present
+    WithOptions {
+        command: String,
+        modifiers: HashSet<I3Modifier>,
+    },
+}
+
+/// A wrapper struct to allow defining a single item or many.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ActionWrapper {
+    Single(Action),
+    Many(Vec<Action>),
+}
+
+/// Custom actions that are configurable per item.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Actions {
+    #[serde(default)]
+    pub left_click: Option<ActionWrapper>,
+    #[serde(default)]
+    pub middle_click: Option<ActionWrapper>,
+    #[serde(default)]
+    pub right_click: Option<ActionWrapper>,
+}
+
+/// Configuration that's common to every item.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Common {
     /// Name of the item. Used in the IPC protocol.
@@ -18,6 +52,8 @@ pub struct Common {
     pub signal: Option<u32>,
     /// Optionally set or unset the separator for this item.
     pub separator: Option<bool>,
+    /// Optionally configure actions for each item
+    pub actions: Option<Actions>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, EnumIter)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-mod item;
+pub mod item;
 mod parse;
 
 use std::cell::OnceCell;

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -88,10 +88,12 @@ pub fn parse(args: &Cli) -> Result<AppConfig> {
                     None => bail!("No file extension, cannot infer file format"),
                 }
 
+                log::trace!("read config file: {}", include.display());
                 seen.insert(include);
             }
         }
     };
 
-    Ok(figment.extract::<AppConfig>()?)
+    let app_config = figment.extract::<AppConfig>()?;
+    Ok(app_config)
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -72,7 +72,8 @@ impl Dispatcher {
                 }
                 Ok(())
             }
-            None | Some(None) => bail!("no item found with index: {}", idx),
+            Some(None) => bail!("item no longer receiving events, index: {}", idx),
+            None => bail!("no item found with index: {}", idx),
         }
     }
 }

--- a/src/i3/click.rs
+++ b/src/i3/click.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use serde_derive::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -18,7 +20,7 @@ pub enum I3Button {
     Unknown,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum I3Modifier {
     Mod1,
     Mod2,
@@ -35,7 +37,7 @@ pub struct I3ClickEvent {
     pub name: Option<String>,
     pub instance: Option<String>,
     pub button: I3Button,
-    pub modifiers: Vec<I3Modifier>,
+    pub modifiers: HashSet<I3Modifier>,
     pub x: usize,
     pub y: usize,
     pub relative_x: usize,

--- a/src/i3/ipc.rs
+++ b/src/i3/ipc.rs
@@ -63,15 +63,15 @@ pub async fn handle_click_events(
         // handle any custom actions
         if let Some(actions) = &config.items[idx].common.actions {
             let did_action = match click.button {
-                I3Button::Left => handle_actions(actions.left_click.as_ref(), &click).await,
-                I3Button::Middle => handle_actions(actions.middle_click.as_ref(), &click).await,
-                I3Button::Right => handle_actions(actions.right_click.as_ref(), &click).await,
+                I3Button::Left => handle_actions(actions.left_click.as_ref(), &click),
+                I3Button::Middle => handle_actions(actions.middle_click.as_ref(), &click),
+                I3Button::Right => handle_actions(actions.right_click.as_ref(), &click),
                 _ => false,
             };
 
             if did_action {
                 log::debug!(
-                    "not forwarding click event to item {} because custom action was set",
+                    "not forwarding click event to item {} because custom action was run",
                     idx
                 );
                 continue;
@@ -86,7 +86,7 @@ pub async fn handle_click_events(
     }
 }
 
-async fn handle_actions(actions: Option<&ActionWrapper>, click: &I3ClickEvent) -> bool {
+fn handle_actions(actions: Option<&ActionWrapper>, click: &I3ClickEvent) -> bool {
     let mut did_action = false;
     let actions = match actions {
         Some(ActionWrapper::Single(action)) => vec![action.clone()],
@@ -104,7 +104,7 @@ async fn handle_actions(actions: Option<&ActionWrapper>, click: &I3ClickEvent) -
         };
 
         if let Some(command) = command {
-            exec(command).await;
+            exec(command);
             did_action = true;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn async_main(args: Cli) -> Result<RuntimeStopReason> {
     // handle our inputs: i3's IPC and our own IPC
     let result = tokio::select! {
         Err(err) = handle_ipc_events(socket, ipc_ctx) => Err(err),
-        Err(err) = handle_click_events(config, dispatcher.clone()) => Err(err),
+        Err(err) = handle_click_events(bar, config, dispatcher.clone()) => Err(err),
         _ = token.cancelled() => Ok(RuntimeStopReason::Shutdown),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ fn handle_item_updates(
 
                     // don't bother doing anything if the item hasn't changed
                     if bar[idx] == i3_item {
+                        log::trace!("not updating item {} because it hasn't changed", idx);
                         continue;
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn async_main(args: Cli) -> Result<RuntimeStopReason> {
     // handle our inputs: i3's IPC and our own IPC
     let result = tokio::select! {
         Err(err) = handle_ipc_events(socket, ipc_ctx) => Err(err),
-        Err(err) = handle_click_events(dispatcher.clone()) => Err(err),
+        Err(err) = handle_click_events(config, dispatcher.clone()) => Err(err),
         _ = token.cancelled() => Ok(RuntimeStopReason::Shutdown),
     };
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -102,10 +102,10 @@ impl Theme {
     }
 
     const DEFAULT_POWERLINE: &[ColorPair] = &[
-        ColorPair::new(HexColor::rgb(216, 222, 233), HexColor::rgb(59, 66, 82)),
-        ColorPair::new(HexColor::rgb(229, 233, 240), HexColor::rgb(67, 76, 94)),
-        ColorPair::new(HexColor::rgb(236, 239, 244), HexColor::rgb(76, 86, 106)),
-        ColorPair::new(HexColor::rgb(229, 233, 240), HexColor::rgb(67, 76, 94)),
+        ColorPair::new(HexColor::rgb(216, 222, 233), HexColor::rgb(46, 52, 64)),
+        ColorPair::new(HexColor::rgb(229, 233, 240), HexColor::rgb(59, 66, 82)),
+        ColorPair::new(HexColor::rgb(236, 239, 244), HexColor::rgb(67, 76, 94)),
+        ColorPair::new(HexColor::rgb(229, 233, 240), HexColor::rgb(59, 66, 82)),
     ];
 
     const fn default_bg() -> HexColor {

--- a/src/util/exec.rs
+++ b/src/util/exec.rs
@@ -1,18 +1,25 @@
 use std::process::Command;
 use std::thread;
 
+use crate::i3::I3Item;
+
 /// Used when bar items need to run an external command. It won't block, and also
 /// won't return any error: it shouldn't crash the app if the child process fails
 /// in any way (just like i3 handles commands).
 ///
 /// Unfortunately there's no `Command::try_wait` equivalent on `tokio::process::Command`,
 /// so this spawns a separate thread for each command, in case the command blocks or waits.
-pub fn exec(cmd: impl AsRef<str>) {
+pub fn exec(cmd: impl AsRef<str>, item: &I3Item) {
     let cmd = cmd.as_ref().to_owned();
     log::debug!("exec: command --> {} <--", &cmd);
 
+    let env_map = item.as_env_map().unwrap();
     thread::spawn(move || {
-        let output = Command::new("sh").arg("-c").arg(&cmd).output();
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(&cmd)
+            .envs(env_map)
+            .output();
         match output {
             Ok(output) => {
                 if !output.status.success() {

--- a/src/util/exec.rs
+++ b/src/util/exec.rs
@@ -7,13 +7,13 @@ use std::thread;
 ///
 /// Unfortunately there's no `Command::try_wait` equivalent on `tokio::process::Command`,
 /// so this spawns a separate thread for each command, in case the command blocks or waits.
-pub async fn exec(cmd: impl AsRef<str>) {
+pub fn exec(cmd: impl AsRef<str>) {
     let cmd = cmd.as_ref().to_owned();
     log::debug!("exec: command --> {} <--", &cmd);
 
     thread::spawn(move || {
-        let child = Command::new("sh").arg("-c").arg(&cmd).output();
-        match child {
+        let output = Command::new("sh").arg("-c").arg(&cmd).output();
+        match output {
             Ok(output) => {
                 if !output.status.success() {
                     log::warn!("exit: command --> {} <-- {}", cmd, output.status);

--- a/src/util/exec.rs
+++ b/src/util/exec.rs
@@ -18,6 +18,9 @@ pub fn exec(cmd: impl AsRef<str>) {
                 if !output.status.success() {
                     log::warn!("exit: command --> {} <-- {}", cmd, output.status);
                 }
+
+                eprintln!("exec stdout: {}", String::from_utf8_lossy(&output.stdout));
+                eprintln!("exec stderr: {}", String::from_utf8_lossy(&output.stderr));
             }
             Err(e) => log::error!("fail: command --> {} <-- {}", cmd, e),
         }

--- a/src/util/exec.rs
+++ b/src/util/exec.rs
@@ -1,19 +1,25 @@
-use tokio::process::Command;
+use std::process::Command;
+use std::thread;
 
 /// Used when bar items need to run an external command. It won't block, and also
 /// won't return any error: it shouldn't crash the app if the child process fails
 /// in any way (just like i3 handles commands).
+///
+/// Unfortunately there's no `Command::try_wait` equivalent on `tokio::process::Command`,
+/// so this spawns a separate thread for each command, in case the command blocks or waits.
 pub async fn exec(cmd: impl AsRef<str>) {
-    let cmd = cmd.as_ref();
-    log::debug!("exec: command --> {} <--", cmd);
+    let cmd = cmd.as_ref().to_owned();
+    log::debug!("exec: command --> {} <--", &cmd);
 
-    let child = Command::new("sh").arg("-c").arg(cmd).output();
-    match child.await {
-        Ok(output) => {
-            if !output.status.success() {
-                log::warn!("exit: command --> {} <-- {}", cmd, output.status);
+    thread::spawn(move || {
+        let child = Command::new("sh").arg("-c").arg(&cmd).output();
+        match child {
+            Ok(output) => {
+                if !output.status.success() {
+                    log::warn!("exit: command --> {} <-- {}", cmd, output.status);
+                }
             }
+            Err(e) => log::error!("fail: command --> {} <-- {}", cmd, e),
         }
-        Err(e) => log::error!("fail: command --> {} <-- {}", cmd, e),
-    }
+    });
 }

--- a/src/util/exec.rs
+++ b/src/util/exec.rs
@@ -18,9 +18,6 @@ pub fn exec(cmd: impl AsRef<str>) {
                 if !output.status.success() {
                     log::warn!("exit: command --> {} <-- {}", cmd, output.status);
                 }
-
-                eprintln!("exec stdout: {}", String::from_utf8_lossy(&output.stdout));
-                eprintln!("exec stderr: {}", String::from_utf8_lossy(&output.stderr));
             }
             Err(e) => log::error!("fail: command --> {} <-- {}", cmd, e),
         }

--- a/src/util/paginator.rs
+++ b/src/util/paginator.rs
@@ -4,6 +4,8 @@ use crate::error::Result;
 use crate::i3::I3Button::*;
 use crate::theme::Theme;
 
+/// A utility struct that is used to help make all items that have multiple items
+/// to show feel consistent. Maps user input (scroll wheel) to different indices.
 pub struct Paginator {
     idx: usize,
     len: usize,
@@ -50,8 +52,8 @@ impl Paginator {
 
     pub fn update(&mut self, event: &BarEvent) {
         match event {
-            BarEvent::Click(c) if matches!(c.button, Left | ScrollUp) => self.incr(),
-            BarEvent::Click(c) if matches!(c.button, Right | ScrollDown) => self.decr(),
+            BarEvent::Click(c) if matches!(c.button, ScrollUp) => self.incr(),
+            BarEvent::Click(c) if matches!(c.button, ScrollDown) => self.decr(),
             _ => {}
         }
     }

--- a/tests/i3/mod.rs
+++ b/tests/i3/mod.rs
@@ -1,3 +1,5 @@
+//! These are full integration tests which run an X server, i3 and use istat as the status bar.
+
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/spawn/actions.rs
+++ b/tests/spawn/actions.rs
@@ -2,7 +2,7 @@ use istat::i3::{I3Button, I3Modifier};
 use serde_json::json;
 
 use crate::spawn::SpawnedProgram;
-use crate::util::Test;
+use crate::util::{get_exe, Test};
 
 spawn_test!(
     actions,
@@ -26,8 +26,9 @@ spawn_test!(
         test.add_fake_file("out", "asdf");
         let echo_name_then_signal = || {
             format!(
-                "#!/usr/bin/env bash\necho -n ${{0##*/}} > /out; echo $PATH; which foo; istat-ipc --socket {} signal 0",
-                test.istat_socket_file.display()
+                "#!/usr/bin/env bash\necho -n ${{0##*/}} > /out; {ipc} --socket {socket} signal 0",
+                ipc = get_exe("istat-ipc").display(),
+                socket = test.istat_socket_file.display()
             )
         };
 
@@ -41,8 +42,6 @@ spawn_test!(
             json!([{ "instance": "0", "name": "script", "full_text": "asdf" }])
         );
 
-        // FIXME: https://github.com/acheronfail/istat/actions/runs/6521800730/job/17710733529?pr=11
-        // in CI it looks like it can't find "foo" command
         istat.click("0", I3Button::Left, &[]);
         assert_eq!(
             istat.next_line_json().unwrap(),

--- a/tests/spawn/actions.rs
+++ b/tests/spawn/actions.rs
@@ -26,7 +26,7 @@ spawn_test!(
         test.add_fake_file("out", "asdf");
         let echo_name_then_signal = || {
             format!(
-                "#!/usr/bin/env bash\necho -n ${{0##*/}} > /out; istat-ipc --socket {} signal 0",
+                "#!/usr/bin/env bash\necho -n ${{0##*/}} > /out; echo $PATH; which foo; istat-ipc --socket {} signal 0",
                 test.istat_socket_file.display()
             )
         };
@@ -41,6 +41,8 @@ spawn_test!(
             json!([{ "instance": "0", "name": "script", "full_text": "asdf" }])
         );
 
+        // FIXME: https://github.com/acheronfail/istat/actions/runs/6521800730/job/17710733529?pr=11
+        // in CI it looks like it can't find "foo" command
         istat.click("0", I3Button::Left, &[]);
         assert_eq!(
             istat.next_line_json().unwrap(),

--- a/tests/spawn/actions.rs
+++ b/tests/spawn/actions.rs
@@ -1,0 +1,67 @@
+use istat::i3::{I3Button, I3Modifier};
+use serde_json::json;
+
+use crate::spawn::SpawnedProgram;
+use crate::util::Test;
+
+spawn_test!(
+    actions,
+    json!({
+      "items": [
+        {
+          "type": "script",
+          "command": "cat /out",
+          "actions": {
+            "left_click": "foo",
+            "middle_click": { "modifiers": ["Shift"], "command": "bar" },
+            "right_click": [
+                { "modifiers": ["Control"], "command": "baz" },
+                { "modifiers": ["Shift"], "command": "foo" },
+            ]
+          }
+        }
+      ]
+    }),
+    |test: &mut Test| {
+        test.add_fake_file("out", "asdf");
+        let echo_name_then_signal = || {
+            format!(
+                "#!/usr/bin/env bash\necho -n ${{0##*/}} > /out; istat-ipc --socket {} signal 0",
+                test.istat_socket_file.display()
+            )
+        };
+
+        test.add_bin("foo", echo_name_then_signal());
+        test.add_bin("bar", echo_name_then_signal());
+        test.add_bin("baz", echo_name_then_signal());
+    },
+    |mut istat: SpawnedProgram| {
+        assert_eq!(
+            istat.next_line_json().unwrap(),
+            json!([{ "instance": "0", "name": "script", "full_text": "asdf" }])
+        );
+
+        istat.click("0", I3Button::Left, &[]);
+        assert_eq!(
+            istat.next_line_json().unwrap(),
+            json!([{ "instance": "0", "name": "script", "full_text": "foo" }])
+        );
+
+        istat.click("0", I3Button::Middle, &[I3Modifier::Shift]);
+        assert_eq!(
+            istat.next_line_json().unwrap(),
+            json!([{ "instance": "0", "name": "script", "full_text": "bar" }])
+        );
+
+        istat.click("0", I3Button::Right, &[I3Modifier::Control]);
+        assert_eq!(
+            istat.next_line_json().unwrap(),
+            json!([{ "instance": "0", "name": "script", "full_text": "baz" }])
+        );
+        istat.click("0", I3Button::Right, &[I3Modifier::Shift]);
+        assert_eq!(
+            istat.next_line_json().unwrap(),
+            json!([{ "instance": "0", "name": "script", "full_text": "foo" }])
+        );
+    }
+);

--- a/tests/spawn/mod.rs
+++ b/tests/spawn/mod.rs
@@ -106,7 +106,7 @@ impl SpawnedProgram {
         self.click_raw(I3ClickEvent {
             instance: Some(target.as_ref().into()),
             button,
-            modifiers: modifiers.to_vec(),
+            modifiers: modifiers.iter().cloned().collect(),
             ..Default::default()
         })
     }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -127,10 +127,9 @@ impl Drop for LogOnDropChild {
         if env::var("DEBUG").is_ok() {
             macro_rules! get {
                 ($std:expr) => {{
-                    let mut r = $std
-                        .take()
-                        .unwrap()
-                        .with_timeout(Duration::from_millis(100));
+                    let mut r = $std.take().unwrap().with_timeout(Duration::from_millis(
+                        if env::var("CI").is_ok() { 1000 } else { 100 },
+                    ));
                     let mut s = String::new();
                     let _ = r.read_to_string(&mut s);
                     s


### PR DESCRIPTION
New features:

*  add `[items.actions]` to every item to configure click actions
    * fixes #10
    * this feature is quite configurable, so see the changes in `sample_config.toml` to see how to use it

Bug fixes:

* fix an issue when calculating the next increment for lights
* fix for `exec`'ing other programs which would block the item that initiated the `exec`
* fix the `krb` item not properly enabling itself

Other changes:

* updated the default powerline colours to match the nord theme (which is the default colour set)
* added more logging when config files import other config files